### PR TITLE
Fix classpath

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -1,6 +1,7 @@
 {
 	"name": "polygonal-printf",
 	"license": "MIT",
+	"classPath": "src",
 	"description": "c printf implementation",
 	"url": "https://github.com/polygonal/printf",
 	"tags": ["cross", "utility"],


### PR DESCRIPTION
I had a weird issue when setting up a build server on windows (VM) and using chocolatey to manage Haxe.

For some reason, I would get
```
Type not found : Printf
```

But everywhere else, it would be fine, turns out adding the classpath inside the haxelib.json did the trick, but I don't understand why I wouldn't get that error anywhere else.