### PR TITLE
Fixed error with float *space* flag when float is negative.

### DIFF
--- a/src/polygonal/Printf.hx
+++ b/src/polygonal/Printf.hx
@@ -866,7 +866,7 @@ class Printf
 			l++;
 		}
 		else
-		if (f.has(Space))
+		if (f.has(Space) && !isNegative)
 		{
 			sign = " ";
 			l++;


### PR DESCRIPTION
Until now a negative float with a format using *space* flag (e.g. "% .2f") would be printed without the minus sign.

I didn't added any test because I'm on Linux and the tooling looks like it's Windows only — but I suppose it will be trivial to add it for you @polygonal .